### PR TITLE
v1.6

### DIFF
--- a/auto-updater.lua
+++ b/auto-updater.lua
@@ -1,12 +1,11 @@
--- Auto-Updater v1.5
+-- Auto-Updater v1.6
 -- by Hexarobi
 -- For Lua Scripts for the Stand Mod Menu for GTA5
 -- Example Usage:
 --    require("auto-updater")
 --    auto_update({
 --        source_url="https://raw.githubusercontent.com/hexarobi/stand-lua-hornsongs/main/HornSongs.lua",
---        script_name=SCRIPT_NAME,
---        script_relpath=SCRIPT_RELPATH,
+--        script_relpath=SCRIPT_RELPATH,  -- Set by Stand automatically for root script file, or can be used for lib files
 --    })
 
 local function string_starts(String,Start)
@@ -74,9 +73,9 @@ local function join_path(parent, child)
 end
 
 local function expand_auto_update_config(auto_update_config)
-    auto_update_config.script_clean_name = auto_update_config.script_name:gsub(".lua", "")
+    auto_update_config.script_name = ("/"..auto_update_config.script_relpath):match("^.*/(.+)[.]lua$")
     auto_update_config.script_path = filesystem.scripts_dir() .. auto_update_config.script_relpath
-    auto_update_config.script_store_dir = filesystem.store_dir() .. auto_update_config.script_clean_name .. '\\'
+    auto_update_config.script_store_dir = filesystem.store_dir() .. auto_update_config.script_name .. '\\'
     ensure_script_store_dir_exists(auto_update_config)
     auto_update_config.version_file = join_path(auto_update_config.script_store_dir, "version.txt")
     if auto_update_config.source_url == nil then        -- For backward compatibility with older configs
@@ -136,6 +135,5 @@ end
 -- Self-apply auto-update to this lib file
 auto_update({
     source_url="https://raw.githubusercontent.com/hexarobi/stand-lua-auto-updater/main/auto-updater.lua",
-    script_name="auto-updater.lua",
     script_relpath="lib/auto-updater.lua",
 })

--- a/auto-updater.lua
+++ b/auto-updater.lua
@@ -91,7 +91,7 @@ local function parse_url_path(url)
     return "/"..url:match("://.-/(.*)")
 end
 
-function auto_update(auto_update_config)
+function run_auto_update(auto_update_config)
     expand_auto_update_config(auto_update_config)
     async_http.init(parse_url_host(auto_update_config.source_url), parse_url_path(auto_update_config.source_url), function(result, headers, status_code)
         if status_code == 304 then
@@ -132,8 +132,13 @@ function auto_update(auto_update_config)
     async_http.dispatch()
 end
 
+-- Wrapper for old function name
+function auto_update(auto_update_config)
+    run_auto_update(auto_update_config)
+end
+
 -- Self-apply auto-update to this lib file
-auto_update({
+run_auto_update({
     source_url="https://raw.githubusercontent.com/hexarobi/stand-lua-auto-updater/main/auto-updater.lua",
     script_relpath="lib/auto-updater.lua",
 })


### PR DESCRIPTION
Deprecate the `script_name` field, and extract it from `script_relpath` instead.